### PR TITLE
Incorrect cuboid volume calcuation, problematic for small dimensions.

### DIFF
--- a/src/net/sacredlabyrinth/Phaed/PreciousStones/entries/CuboidEntry.java
+++ b/src/net/sacredlabyrinth/Phaed/PreciousStones/entries/CuboidEntry.java
@@ -308,7 +308,7 @@ public class CuboidEntry
      */
     public boolean isExceeded()
     {
-        int testVolume = (maxy - miny) * (maxx - minx) * (maxz - minz);
+        int testVolume = ((maxy - miny)+1) * ((maxx - minx)+1) * ((maxz - minz)+1);
 
         return testVolume > getMaxVolume();
     }


### PR DESCRIPTION
The volume calculation was incorrect.  For example, if minx,miny,minz were 0,0,0, and maxx, maxy, maxz were 2,2,2, that is a 3x3x3 cube, with a volume of 27.  However, the calculation that was used was the difference for each axis, in this case 2 \* 2 *2, for a volume of 8.  Basically, the calculation was giving a free block in each direction for volume, and a volume only one block thick in any direction would be calculated as zero (e.g., a very large wall in X and Y but only a single block Z would be zero volume by the old calculation).

Just adding one to each difference gives the correct result, 1 volume for a single cube, and so forth.
