### PR TITLE
Fix non-cuboid fields not updating. Fixes #590.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/MySQLCore.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/MySQLCore.java
@@ -257,14 +257,14 @@ public class MySQLCore implements DBCore
             finally
             {
                 statement.close();
-                return true;
             }
         }
         catch (SQLException ex)
         {
-            log.severe(ex.getMessage());
+            log.severe("Error at SQL Query: " + ex.getMessage());
             return false;
         }
+        return true;
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/SQLiteCore.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/SQLiteCore.java
@@ -257,22 +257,21 @@ public class SQLiteCore implements DBCore
         try
         {
             Statement statement = getConnection().createStatement();
-            Boolean result = false;
             try
             {
-                result = statement.execute(query);
+                statement.execute(query);
             }
             finally
             {
                 statement.close();
-                return result;
             }
         }
         catch (SQLException ex)
         {
-            log.severe(ex.getMessage());
+            log.severe("Error at SQL Query: " + ex.getMessage());
             return false;
         }
+        return true;
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/vectors/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/vectors/Field.java
@@ -209,7 +209,10 @@ public class Field extends AbstractVec implements Comparable<Field>
             this.maxy = getY() + ((height - 1) / 2);
         }
 
-        dirty.add(DirtyFieldReason.DIMENSIONS);
+        if (hasFlag(FieldFlag.CUBOID))
+        {
+            dirty.add(DirtyFieldReason.DIMENSIONS);
+        }
     }
 
     /**


### PR DESCRIPTION
Non-cuboid fields should never have their `DirtyFieldReason.DIMENSIONS` property set, this will cause the UPDATE query to fail.

This pull request fixes that simply by adding a check before adding that flag. There are maybe other, better, solutions, but this seemed a simple solution to me that just works.

The error message of the query wasn't displayed because SQL errors were ignored by the `DBCore.execute` method: the method ended in the `finally` block. This pull request also fixes that problem.

This pull request might also fix issues #664, #652, #651, #636 and #617, but I'm not sure if those issues are actually caused by this bug.
