### PR TITLE
Fix items in item frames being shot off. Fixes #725

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/Helper.java
@@ -3,8 +3,13 @@ package net.sacredlabyrinth.Phaed.PreciousStones;
 import net.sacredlabyrinth.Phaed.PreciousStones.entries.BlockTypeEntry;
 import org.bukkit.*;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.projectiles.ProjectileSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -870,5 +875,43 @@ public class Helper
     {
         int id = loc.getWorld().getBlockTypeIdAt(loc);
         return id == 0 || id == 8 || id == 9;
+    }
+
+    /**
+     * Gets the player that was responsible for the damage. If no player was
+     * responsible, <code>null</code> is returned.
+     *
+     * <ul>
+     *     <li>If the entity was damaged by a player, that player
+     *     is returned.</li>
+     *     <li>If the entity was damaged by a projectile, and the projectile
+     *     was shot by a player, that player is returned.</li>
+     * </ul>
+     *
+     * @param event The damage event.
+     * @return The player, or <code>null</code> if not found.
+     */
+    public static Player getDamagingPlayer(EntityDamageEvent event)
+    {
+        if (!(event instanceof EntityDamageByEntityEvent))
+        {
+            return null;
+        }
+
+        Entity damager = ((EntityDamageByEntityEvent) event).getDamager();
+        if (damager instanceof Player)
+        {
+            return (Player) damager;
+        }
+        if (damager instanceof Projectile)
+        {
+            ProjectileSource shooter = ((Projectile) damager).getShooter();
+            if (shooter instanceof Player)
+            {
+                return (Player) shooter;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
@@ -1,6 +1,7 @@
 package net.sacredlabyrinth.Phaed.PreciousStones.listeners;
 
 import net.sacredlabyrinth.Phaed.PreciousStones.FieldFlag;
+import net.sacredlabyrinth.Phaed.PreciousStones.Helper;
 import net.sacredlabyrinth.Phaed.PreciousStones.PreciousStones;
 import net.sacredlabyrinth.Phaed.PreciousStones.SignHelper;
 import net.sacredlabyrinth.Phaed.PreciousStones.entries.BlockEntry;
@@ -543,25 +544,17 @@ public class PSEntityListener implements Listener
 
         if (event.getEntity() instanceof ItemFrame)
         {
-            if (event instanceof EntityDamageByEntityEvent)
+            Player player = Helper.getDamagingPlayer(event);
+
+            if (player == null || !plugin.getPermissionsManager().has(player, "preciousstones.bypass.item-frame-take"))
             {
-                EntityDamageByEntityEvent sub = (EntityDamageByEntityEvent) event;
+                Field field = plugin.getForceFieldManager().getEnabledSourceField(event.getEntity().getLocation(), FieldFlag.PREVENT_ITEM_FRAME_TAKE);
 
-                if (sub.getDamager() instanceof Player)
+                if (field != null)
                 {
-                    Player player = (Player) sub.getDamager();
-
-                    if (!plugin.getPermissionsManager().has(player, "preciousstones.bypass.item-frame-take"))
+                    if (FieldFlag.PREVENT_ITEM_FRAME_TAKE.applies(field, player))
                     {
-                        Field field = plugin.getForceFieldManager().getEnabledSourceField(event.getEntity().getLocation(), FieldFlag.PREVENT_ITEM_FRAME_TAKE);
-
-                        if (field != null)
-                        {
-                            if (FieldFlag.PREVENT_ITEM_FRAME_TAKE.applies(field, player))
-                            {
-                                event.setCancelled(true);
-                            }
-                        }
+                        event.setCancelled(true);
                     }
                 }
             }


### PR DESCRIPTION
Fixes the following cases:
- A player shoots an item out of the frame with an arrow
- A player tricks a skeleton into shooting an item of an item frame

Previously, the item would pop off in both cases, now it remains intact.

---

As the logic to determine which player was responsible for the damage event became quite big, I put it in a new method, getDamagingPlayer. I placed the method in the Helper class, I hope that it's the correct location.

---

Tested on CraftBukkit Beta 1.7.9-R0.2 (build 3092).
