### PR TITLE
Take fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+target
+*.iml
+*.jar

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/PurchaseEntry.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/PurchaseEntry.java
@@ -36,7 +36,7 @@ public class PurchaseEntry {
     }
 
     public boolean isItemPayment() {
-        return item != null;
+        return item != null && item.getMaterial() != null;
     }
 
     public int getAmount() {

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -17,6 +17,8 @@ import net.sacredlabyrinth.Phaed.PreciousStones.vectors.Vec;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
@@ -1315,7 +1317,17 @@ public class Field extends AbstractVec implements Comparable<Field> {
 
         PreciousStones.getInstance().getForceFieldManager().deleteField(this);
         block.setType(Material.AIR);
-        StackHelper.give(player, type, 1);
+
+        ItemStack is = new ItemStack(type.getTypeId(), 1, (short) 0, type.getData());
+
+        if (settings.hasMetaName()) {
+            ItemMeta meta = is.getItemMeta();
+            meta.setDisplayName(settings.getMetaName());
+            meta.setLore(settings.getMetaLore());
+            is.setItemMeta(meta);
+        }
+
+        StackHelper.give(player, is);
         return true;
     }
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/StackHelper.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/StackHelper.java
@@ -60,6 +60,18 @@ public class StackHelper {
         player.updateInventory();
     }
 
+    public static void give(Player player, ItemStack stack) {
+        HashMap<Integer, ItemStack> rem = player.getInventory().addItem(stack);
+
+        if (rem != null && !rem.isEmpty()) {
+            for (ItemStack is : rem.values()) {
+                player.getWorld().dropItemNaturally(player.getLocation(), is);
+            }
+        }
+
+        player.updateInventory();
+    }
+
     public static List<ItemStack> makeStacks(BlockTypeEntry item, int amount) {
         List<ItemStack> out = new ArrayList<ItemStack>();
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
@@ -110,13 +110,13 @@ public class CommunicationManager {
 
     public void logPurchase(String owner, String renter, PurchaseEntry purchase, FieldSign s) {
         if (plugin.getSettingsManager().isLogRentsAndPurchases()) {
-            PreciousStones.log("logPurchase", renter, owner, s.getField().getSettings().getTitle(), purchase.getAmount(), (purchase.getItem() != null) ? purchase.getItem() : "", purchase.getCoords());
+            PreciousStones.log("logPurchase", renter, owner, s.getField().getSettings().getTitle(), purchase.getAmount(), purchase.isItemPayment() ? purchase.getItem() : "", purchase.getCoords());
         }
     }
 
     public void logPurchaseCollect(String owner, String renter, PurchaseEntry purchase) {
         if (plugin.getSettingsManager().isLogRentsAndPurchases()) {
-            PreciousStones.log("logPurchaseCollect", owner, purchase.getAmount(), (purchase.getItem() != null) ? purchase.getItem() : "", renter, purchase.getCoords());
+            PreciousStones.log("logPurchaseCollect", owner, purchase.getAmount(), purchase.isItemPayment() ? purchase.getItem() : "", renter, purchase.getCoords());
         }
     }
 


### PR DESCRIPTION
This fixes a couple more issues with non-item buys, and also fixes "/ps take" when used on lored stones. 

Currently, there is an issue when using lored stones, a player will /ps take and just get a normal block.