### PR TITLE
Fixes for Accidental PStone Breakage

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/PreciousStones.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/PreciousStones.java
@@ -60,6 +60,7 @@ public class PreciousStones extends JavaPlugin {
     private PSWorldListener worldListener;
     private PSVehicleListener vehicleListener;
     private PSServerListener serverListener;
+    private PSInventoryListener inventoryListener;
     private McMMOListener mcmmoListener;
     private LWCListener lwcListener;
     private static IApi api;
@@ -159,6 +160,7 @@ public class PreciousStones extends JavaPlugin {
         vehicleListener = new PSVehicleListener();
         worldListener = new PSWorldListener();
         serverListener = new PSServerListener();
+        inventoryListener = new PSInventoryListener();
 
         if (permissionsManager.hasMcMMO()) {
             mcmmoListener = new McMMOListener();
@@ -217,6 +219,7 @@ public class PreciousStones extends JavaPlugin {
         getServer().getPluginManager().registerEvents(blockListener, this);
         getServer().getPluginManager().registerEvents(vehicleListener, this);
         getServer().getPluginManager().registerEvents(worldListener, this);
+        getServer().getPluginManager().registerEvents(inventoryListener, this);
 
         if (permissionsManager.hasMcMMO()) {
             getServer().getPluginManager().registerEvents(mcmmoListener, this);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/BlockTypeEntry.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/BlockTypeEntry.java
@@ -4,6 +4,7 @@ import net.sacredlabyrinth.Phaed.PreciousStones.MaterialName;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,6 +22,11 @@ public class BlockTypeEntry {
     public BlockTypeEntry(Block block) {
         this.material = block.getType();
         this.data = block.getData();
+    }
+
+    public BlockTypeEntry(ItemStack item) {
+        this.material = item.getType();
+        this.data = (byte)item.getDurability();
     }
 
     /**

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
@@ -614,6 +614,10 @@ public class PSBlockListener implements Listener {
         }
 
         if (plugin.getSettingsManager().isBlacklistedWorld(block.getWorld())) {
+            // Prevent destorying pstones with meta by trying to place them in a disabled world
+            if (plugin.getSettingsManager().isMetaFieldType(handItem)) {
+                event.setCancelled(true);
+            }
             return;
         }
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
@@ -17,21 +17,29 @@ public class PSInventoryListener implements Listener {
         plugin = PreciousStones.getInstance();
     }
 
-    @EventHandler
+    protected boolean isMetaField(ItemStack item) {
+        return item != null && item.getType() != Material.AIR && item.hasItemMeta() && plugin.getSettingsManager().isFieldType(new BlockTypeEntry(item), item);
+    }
+
+    @EventHandler(ignoreCancelled = true)
     public void onInventoryClick(InventoryClickEvent event) {
         if (event.isCancelled()) return;
         if (!(event.getWhoClicked() instanceof Player)) return;
-        if (event.getInventory().getType() != InventoryType.ANVIL) return;
 
+        InventoryType inventoryType = event.getInventory().getType();
+        InventoryType.SlotType slotType = event.getSlotType();
         ItemStack cursor = event.getCursor();
         ItemStack current = event.getCurrentItem();
 
-        if (cursor != null && cursor.getType() != Material.AIR &&
-            plugin.getSettingsManager().isFieldType(new BlockTypeEntry(cursor), cursor)) {
-            event.setCancelled(true);
-        } else if (current != null && current.getType() != Material.AIR &&
-                plugin.getSettingsManager().isFieldType(new BlockTypeEntry(current), current)) {
-            event.setCancelled(true);
+        if (inventoryType == InventoryType.ANVIL) {
+            // Have to check "current" here as well to avoid shift+clicks
+            if (isMetaField(cursor) || isMetaField(current)) {
+                event.setCancelled(true);
+            }
+        } else if (slotType == InventoryType.SlotType.CRAFTING && (inventoryType == InventoryType.CRAFTING || inventoryType == InventoryType.WORKBENCH)) {
+            if (isMetaField(cursor)) {
+                event.setCancelled(true);
+            }
         }
     }
 }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
@@ -1,0 +1,37 @@
+package net.sacredlabyrinth.Phaed.PreciousStones.listeners;
+
+import net.sacredlabyrinth.Phaed.PreciousStones.PreciousStones;
+import net.sacredlabyrinth.Phaed.PreciousStones.entries.BlockTypeEntry;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.ItemStack;
+
+public class PSInventoryListener implements Listener {
+    private final PreciousStones plugin;
+
+    public PSInventoryListener() {
+        plugin = PreciousStones.getInstance();
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (event.isCancelled()) return;
+        if (!(event.getWhoClicked() instanceof Player)) return;
+        if (event.getInventory().getType() != InventoryType.ANVIL) return;
+
+        ItemStack cursor = event.getCursor();
+        ItemStack current = event.getCurrentItem();
+
+        if (cursor != null && cursor.getType() != Material.AIR &&
+            plugin.getSettingsManager().isFieldType(new BlockTypeEntry(cursor), cursor)) {
+            event.setCancelled(true);
+        } else if (current != null && current.getType() != Material.AIR &&
+                plugin.getSettingsManager().isFieldType(new BlockTypeEntry(current), current)) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSInventoryListener.java
@@ -1,8 +1,7 @@
 package net.sacredlabyrinth.Phaed.PreciousStones.listeners;
 
 import net.sacredlabyrinth.Phaed.PreciousStones.PreciousStones;
-import net.sacredlabyrinth.Phaed.PreciousStones.entries.BlockTypeEntry;
-import org.bukkit.Material;
+import net.sacredlabyrinth.Phaed.PreciousStones.managers.SettingsManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -17,10 +16,6 @@ public class PSInventoryListener implements Listener {
         plugin = PreciousStones.getInstance();
     }
 
-    protected boolean isMetaField(ItemStack item) {
-        return item != null && item.getType() != Material.AIR && item.hasItemMeta() && plugin.getSettingsManager().isFieldType(new BlockTypeEntry(item), item);
-    }
-
     @EventHandler(ignoreCancelled = true)
     public void onInventoryClick(InventoryClickEvent event) {
         if (event.isCancelled()) return;
@@ -30,14 +25,15 @@ public class PSInventoryListener implements Listener {
         InventoryType.SlotType slotType = event.getSlotType();
         ItemStack cursor = event.getCursor();
         ItemStack current = event.getCurrentItem();
+        SettingsManager manager = plugin.getSettingsManager();
 
         if (inventoryType == InventoryType.ANVIL) {
             // Have to check "current" here as well to avoid shift+clicks
-            if (isMetaField(cursor) || isMetaField(current)) {
+            if (manager.isMetaFieldType(cursor) || manager.isMetaFieldType(current)) {
                 event.setCancelled(true);
             }
         } else if (slotType == InventoryType.SlotType.CRAFTING && (inventoryType == InventoryType.CRAFTING || inventoryType == InventoryType.WORKBENCH)) {
-            if (isMetaField(cursor)) {
+            if (manager.isMetaFieldType(cursor)) {
                 event.setCancelled(true);
             }
         }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SettingsManager.java
@@ -747,6 +747,16 @@ public final class SettingsManager {
     }
 
     /**
+     * Check if an item is a field type with meta attached to it.
+     *
+     * @param item The item to check
+     * @return true if the item is a meta field stone
+     */
+    public boolean isMetaFieldType(ItemStack item) {
+        return item != null && item.getType() != Material.AIR && item.hasItemMeta() && isFieldType(new BlockTypeEntry(item), item);
+    }
+
+    /**
      * Whetehr the block is a bypass type
      *
      * @param block


### PR DESCRIPTION
This PR applies only to stones with meta defined.

It will prevent accidental breakage of pstones by players:
- Attempting to place a field in a blacklisted world
- Attempting to rename a stone on an anvil
- Crafting a stone, when the field type is an item that can be broken down