### PR TITLE
Fix Player Tracking and Name Change Migration

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/RentEntry.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/RentEntry.java
@@ -58,6 +58,10 @@ public class RentEntry {
         return this.getPlayerName().hashCode();
     }
 
+    public void setPlayerName(String playerName) {
+        this.playerName = playerName;
+    }
+
     public String serialize() {
         return playerName + "|" + periodSeconds + "|" + endDate.getMillis();
     }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -604,6 +604,19 @@ public class Field extends AbstractVec implements Comparable<Field> {
         dirty.add(DirtyFieldReason.ALLOWED);
     }
 
+    public boolean migrateAllowed(String oldPlayerName, String newPlayerName) {
+        oldPlayerName = oldPlayerName.toLowerCase();
+        for (int i = 0; i < allowed.size(); i++) {
+            if (allowed.get(i).equals(oldPlayerName)) {
+                dirty.add(DirtyFieldReason.ALLOWED);
+                allowed.set(i, newPlayerName.toLowerCase());
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return coordinates string format [x y z world]
      */

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
@@ -482,7 +482,7 @@ public class PSBlockListener implements Listener {
 
         if (settings != null) {
             if (settings.isMetaAutoSet()) {
-                PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player);
                 if (!playerEntry.isDisabled()) {
                     block.getDrops().clear();
                     plugin.getForceFieldManager().dropBlock(block, new BlockTypeEntry(block), settings);
@@ -740,7 +740,7 @@ public class PSBlockListener implements Listener {
 
         // if the user has it manually off then disable placing
 
-        if (plugin.getPlayerManager().getPlayerEntry(player.getName()).isDisabled()) {
+        if (plugin.getPlayerManager().getPlayerEntry(player).isDisabled()) {
             isDisabled = true;
         }
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSEntityListener.java
@@ -946,7 +946,7 @@ public class PSEntityListener implements Listener {
 
             if (entity instanceof Player) {
                 Player player = (Player) entity;
-                PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player);
                 if (playerEntry.isDisabled()) {
                     return;
                 }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSPlayerListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSPlayerListener.java
@@ -82,8 +82,7 @@ public class PSPlayerListener implements Listener {
         final Player player = event.getPlayer();
         final String playerName = event.getPlayer().getName();
 
-        plugin.getPlayerManager().playerLogin(playerName);
-        plugin.getStorageManager().findUUIDMismatch(player);
+        plugin.getPlayerManager().playerLogin(player);
         plugin.getStorageManager().offerPlayer(playerName);
 
         plugin.getEntryManager().reevaluateEnteredFields(player);
@@ -367,7 +366,7 @@ public class PSPlayerListener implements Listener {
 
                     if (futureField.getSettings().isTeleportHasItem(new BlockTypeEntry(stack.getType()))) {
                         if (FieldFlag.TELEPORT_IF_HAS_ITEMS.applies(futureField, player)) {
-                            PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                            PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                             if (!entry.isTeleporting()) {
                                 entry.setTeleporting(true);
@@ -391,7 +390,7 @@ public class PSPlayerListener implements Listener {
 
                 if (!hasItem) {
                     if (FieldFlag.TELEPORT_IF_NOT_HAS_ITEMS.applies(futureField, player)) {
-                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                         if (!entry.isTeleporting()) {
                             entry.setTeleporting(true);
@@ -412,7 +411,7 @@ public class PSPlayerListener implements Listener {
             if (itemInHand != null && itemInHand.getTypeId() != 0) {
                 if (futureField.getSettings().isTeleportHoldingItem(new BlockTypeEntry(itemInHand.getType()))) {
                     if (FieldFlag.TELEPORT_IF_HOLDING_ITEMS.applies(futureField, player)) {
-                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                         if (!entry.isTeleporting()) {
                             entry.setTeleporting(true);
@@ -433,7 +432,7 @@ public class PSPlayerListener implements Listener {
             if (itemInHand != null && itemInHand.getTypeId() != 0) {
                 if (!futureField.getSettings().isTeleportNotHoldingItem(new BlockTypeEntry(itemInHand.getType()))) {
                     if (FieldFlag.TELEPORT_IF_NOT_HOLDING_ITEMS.applies(futureField, player)) {
-                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                         if (!entry.isTeleporting()) {
                             entry.setTeleporting(true);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommandManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommandManager.java
@@ -80,18 +80,18 @@ public final class CommandManager implements CommandExecutor {
                         plugin.getCommunicationManager().showConfiguredFields(sender);
                         return true;
                     } else if (cmd.equals(ChatHelper.format("commandOn")) && plugin.getPermissionsManager().has(player, "preciousstones.benefit.onoff") && hasplayer) {
-                        boolean isDisabled = hasplayer && plugin.getPlayerManager().getPlayerEntry(player.getName()).isDisabled();
+                        boolean isDisabled = hasplayer && plugin.getPlayerManager().getPlayerEntry(player).isDisabled();
                         if (isDisabled) {
-                            plugin.getPlayerManager().getPlayerEntry(player.getName()).setDisabled(false);
+                            plugin.getPlayerManager().getPlayerEntry(player).setDisabled(false);
                             ChatHelper.send(sender, "placingEnabled");
                         } else {
                             ChatHelper.send(sender, "placingAlreadyEnabled");
                         }
                         return true;
                     } else if (cmd.equals(ChatHelper.format("commandOff")) && plugin.getPermissionsManager().has(player, "preciousstones.benefit.onoff") && hasplayer) {
-                        boolean isDisabled = hasplayer && plugin.getPlayerManager().getPlayerEntry(player.getName()).isDisabled();
+                        boolean isDisabled = hasplayer && plugin.getPlayerManager().getPlayerEntry(player).isDisabled();
                         if (!isDisabled) {
-                            plugin.getPlayerManager().getPlayerEntry(player.getName()).setDisabled(true);
+                            plugin.getPlayerManager().getPlayerEntry(player).setDisabled(true);
                             ChatHelper.send(sender, "placingDisabled");
                         } else {
                             ChatHelper.send(sender, "placingAlreadyDisabled");
@@ -738,14 +738,14 @@ public final class CommandManager implements CommandExecutor {
                         if (args.length == 1 && Helper.isInteger(args[0])) {
                             int density = Integer.parseInt(args[0]);
 
-                            PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                            PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player);
                             data.setDensity(density);
                             plugin.getStorageManager().offerPlayer(player.getName());
 
                             ChatHelper.send(sender, "visualizationChanged", density);
                             return true;
                         } else if (args.length == 0) {
-                            PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                            PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player);
                             ChatHelper.send(sender, "visualizationSet", data.getDensity());
                         }
                     } else if (cmd.equals(ChatHelper.format("commandToggle")) && plugin.getPermissionsManager().has(player, "preciousstones.benefit.toggle") && hasplayer) {
@@ -1815,7 +1815,7 @@ public final class CommandManager implements CommandExecutor {
                             return true;
                         }
                     } else if (cmd.equals(ChatHelper.format("commandBypass")) && plugin.getPermissionsManager().has(player, "preciousstones.bypass.toggle")) {
-                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                         if (args.length == 1) {
                             String mode = args[0];

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ConfiscationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ConfiscationManager.java
@@ -109,7 +109,7 @@ public class ConfiscationManager {
         }
 
         if (!confiscated.isEmpty() || helmet != null || chestplate != null || leggings != null || boots != null) {
-            PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+            PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
             entry.confiscate(confiscated, helmet, chestplate, leggings, boots);
             plugin.getStorageManager().updatePlayer(player.getName());
             player.updateInventory();
@@ -155,7 +155,7 @@ public class ConfiscationManager {
             return;
         }
 
-        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+        PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
         List<ItemStackEntry> confiscated = entry.returnInventory();
         ItemStackEntry helmet = entry.returnHelmet();

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PermissionsManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PermissionsManager.java
@@ -151,7 +151,7 @@ public final class PermissionsManager {
 
         if (!perm.contains("preciousstones.bypass.toggle")) {
             if (perm.contains("preciousstones.bypass.") || perm.contains("preciousstones.admin.allowed")) {
-                PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                PlayerEntry entry = plugin.getPlayerManager().getPlayerEntry(player);
 
                 if (entry.isBypassDisabled()) {
                     return false;

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/TeleportationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/TeleportationManager.java
@@ -85,7 +85,7 @@ public class TeleportationManager {
             if (entity instanceof Player) {
                 Player player = (Player) entity;
 
-                plugin.getPlayerManager().getPlayerEntry(player.getName()).setTeleporting(false);
+                plugin.getPlayerManager().getPlayerEntry(player).setTeleporting(false);
 
                 // done teleport players with bypass permission
 
@@ -151,7 +151,7 @@ public class TeleportationManager {
                         ChatHelper.send(player, "teleportAnnounceBack", sourceField.getSettings().getTeleportBackAfterSeconds());
                     }
 
-                    PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player.getName());
+                    PlayerEntry playerEntry = plugin.getPlayerManager().getPlayerEntry(player);
 
                     playerEntry.setTeleportSecondsRemaining(sourceField.getSettings().getTeleportBackAfterSeconds());
                     playerEntry.setTeleportVec(currentPosition);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/VisualizationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/VisualizationManager.java
@@ -100,7 +100,7 @@ public class VisualizationManager {
             return;
         }
 
-        PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player.getName());
+        PlayerEntry data = plugin.getPlayerManager().getPlayerEntry(player);
 
         if (data.getDensity() == 0) {
             return;

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/modules/RentingModule.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/modules/RentingModule.java
@@ -50,6 +50,24 @@ public class RentingModule {
         return !renters.isEmpty();
     }
 
+    public void migrateRenters(String oldName, String newName) {
+        for (RentEntry entry : renterEntries) {
+            if (entry.getPlayerName().equals(oldName)) {
+                entry.setPlayerName(newName);
+                cleanFieldSign();
+                break;
+            }
+        }
+        oldName = oldName.toLowerCase();
+        for (int i = 0; i < renters.size(); i++) {
+            if (renters.get(i).equalsIgnoreCase(oldName)) {
+                renters.set(i, oldName.toLowerCase());
+                break;
+            }
+        }
+        field.getFlagsModule().dirtyFlags("addRent");
+    }
+
     public void clearRenters() {
         PreciousStones.getInstance().getForceFieldManager().removeAllRenters(field);
         renterEntries.clear();


### PR DESCRIPTION
This fixes a bug tracking players in the pstone_players table. I think the bug was as follows:
- New PlayerEntry records would not get a UUID assigned (only a name)
- When saving a null UUID, the "null" string was saved instead of null (maybe due to call to uuid.toString?)
- When player re-joins, a check for "uuid == null" fails, so UUID lookup doesn't happen

This, combined with the UNIQUE index of the uuid column, means new player data would never get saved, due to the "null" string conflict for all players.

I have fixed this, changing most methods that look up players to use a Player object when available, and to make sure the UUID gets assigned in all cases.

Additionally, I have improved the name change migration to work for allowed players and renters as well. These could both stand to be optimized by changing the ArrayLists to HashMaps, and perhaps track a HashMap of players to their allowed fields.

I have this deployed on a live server and so far it is going well. I see the pstone_players table populating now (we only had one record before, me, the first player to join) with valid UUIDs.

I haven't had a real name change happen yet with the fix, but I tested locally by modifying the database directly and it seemed to handle all the cases. I will follow up with any bug fixes and optimizations!