### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/MaterialName.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/MaterialName.java
@@ -3,6 +3,10 @@ package net.sacredlabyrinth.Phaed.PreciousStones;
 import org.bukkit.Material;
 
 public class MaterialName {
+    
+    private MaterialName() {
+        
+    }
 
     public static String getIDName(Material mate) {
         switch (mate) {

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/SignHelper.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/SignHelper.java
@@ -14,6 +14,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class SignHelper {
+    
+    private SignHelper() {
+        
+    }
+    
     /**
      * check if a block is a sign
      *

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/StackHelper.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/StackHelper.java
@@ -11,6 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 
 public class StackHelper {
+    
+    private StackHelper() {
+        
+    }
+    
     public static void unHoldItem(Player player, int slot) {
         PlayerInventory inv = player.getInventory();
         ItemStack item = inv.getItem(slot);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/uuid/UUIDMigration.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/uuid/UUIDMigration.java
@@ -11,6 +11,10 @@ import java.util.UUID;
  * @author NeT32
  */
 public class UUIDMigration {
+    
+    private UUIDMigration() {
+        
+    }
 
     public static boolean canReturnUUID() {
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed