### PR TITLE
Code quality fix - Objects should be compared with "equals().

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/listeners/PSBlockListener.java
@@ -845,7 +845,7 @@ public class PSBlockListener implements Listener {
                     Field field1 = plugin.getForceFieldManager().getConflictSourceField(block.getRelative(BlockFace.EAST).getLocation(), player.getName(), FieldFlag.ALL);
 
                     if (field1 != null) {
-                        if (field == null || field != field1) {
+                        if (field == null || field.equals(field1)) {
                             conflicted = true;
                         }
                     }
@@ -855,7 +855,7 @@ public class PSBlockListener implements Listener {
                     Field field2 = plugin.getForceFieldManager().getConflictSourceField(block.getRelative(BlockFace.WEST).getLocation(), player.getName(), FieldFlag.ALL);
 
                     if (field2 != null) {
-                        if (field == null || field != field2) {
+                        if (field == null || field.equals(field2)) {
                             conflicted = true;
                         }
                     }
@@ -865,7 +865,7 @@ public class PSBlockListener implements Listener {
                     Field field3 = plugin.getForceFieldManager().getConflictSourceField(block.getRelative(BlockFace.NORTH).getLocation(), player.getName(), FieldFlag.ALL);
 
                     if (field3 != null) {
-                        if (field == null || field != field3) {
+                        if (field == null || field.equals(field3)) {
                             conflicted = true;
                         }
                     }
@@ -875,7 +875,7 @@ public class PSBlockListener implements Listener {
                     Field field4 = plugin.getForceFieldManager().getConflictSourceField(block.getRelative(BlockFace.SOUTH).getLocation(), player.getName(), FieldFlag.ALL);
 
                     if (field4 != null) {
-                        if (field == null || field != field4) {
+                        if (field == null || field.equals(field4)) {
                             conflicted = true;
                         }
                     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1698 - Objects should be compared with "equals(). 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1698
 
Please let me know if you have any questions.

Faisal Hameed