### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/Timing.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/Timing.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.time.DurationFormatUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class Timing {
     private String title;
@@ -30,8 +31,8 @@ public class Timing {
         PreciousStones.debug(title + " Timings");
         PreciousStones.debug("----------------------------------------------------------------------");
 
-        for (String name : times.keySet()) {
-            Long time = times.get(name);
+        for ( Entry<String, Long> timeObj : times.entrySet()) {
+            Long time = timeObj.getValue();
 
             if (previousTime == -9999L) {
                 previousTime = time;
@@ -41,7 +42,7 @@ public class Timing {
             long duration = Math.max(time - previousTime, 0);
             String friendlyDuration = DurationFormatUtils.formatDuration(duration, "ss.SSS");
 
-            PreciousStones.debug(friendlyDuration + "  " + name);
+            PreciousStones.debug(friendlyDuration + "  " + timeObj.getKey());
             previousTime = time;
         }
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/ItemStackEntry.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/ItemStackEntry.java
@@ -6,6 +6,7 @@ import org.json.simple.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * @author phaed
@@ -131,8 +132,8 @@ public class ItemStackEntry {
     public ItemStack toItemStack() {
         ItemStack is = new ItemStack(getTypeId(), getAmount(), getDurability(), getData());
 
-        for (Enchantment ench : enchantments.keySet()) {
-            is.addUnsafeEnchantment(ench, Math.min(enchantments.get(ench), ench.getMaxLevel()));
+        for (Entry<Enchantment, Integer> ench : enchantments.entrySet()) {
+            is.addUnsafeEnchantment(ench.getKey(), Math.min(ench.getValue(), ench.getKey().getMaxLevel()));
         }
 
         return is;

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
@@ -23,6 +23,7 @@ import org.bukkit.entity.Vehicle;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * @author phaed
@@ -192,10 +193,10 @@ public class CommunicationManager {
 
         Map<String, Integer> details = plugin.getStorageManager().getTranslocationDetails(player.getName());
 
-        for (String name : details.keySet()) {
-            int count = details.get(name);
+        for (Entry<String, Integer> detail : details.entrySet()) {
+            int count = detail.getValue();
 
-            cb.addRow("  " + ChatColor.WHITE + name, ChatColor.WHITE + " " + count);
+            cb.addRow("  " + ChatColor.WHITE + detail.getKey(), ChatColor.WHITE + " " + count);
         }
 
         if (cb.size() > 1) {
@@ -2380,11 +2381,11 @@ public class CommunicationManager {
 
         cb.addRow("  " + ChatColor.GRAY + ChatHelper.format("_name"), ChatHelper.format("_count"));
 
-        for (String playerName : fieldsByOwner.keySet()) {
-            int count = fieldsByOwner.get(playerName).size();
+        for (Entry<String, List<Field>> playerFields : fieldsByOwner.entrySet()) {
+            int count = playerFields.getValue().size();
 
             if (count > 0) {
-                cb.addRow("  " + ChatColor.AQUA + playerName, ChatColor.WHITE + " " + count);
+                cb.addRow("  " + ChatColor.AQUA + playerFields.getKey(), ChatColor.WHITE + " " + count);
             }
         }
 
@@ -2440,14 +2441,14 @@ public class CommunicationManager {
 
         fieldCounts = plugin.getForceFieldManager().getFieldCounts(target);
 
-        for (BlockTypeEntry type : fieldCounts.keySet()) {
-            int count = fieldCounts.get(type);
+        for (Entry<BlockTypeEntry, Integer> fieldCount : fieldCounts.entrySet()) {
+            int count = fieldCount.getValue();
 
             if (count == 0) {
                 continue;
             }
 
-            FieldSettings fs = plugin.getSettingsManager().getFieldSettings(type);
+            FieldSettings fs = plugin.getSettingsManager().getFieldSettings(fieldCount.getKey());
 
             if (fs == null) {
                 continue;

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
@@ -17,6 +17,7 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.potion.PotionEffectType;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Handles what happens inside fields
@@ -70,14 +71,14 @@ public final class EntryManager {
 
     private void doEffects() {
         try {
-            for (String playerName : dynamicEntries.keySet()) {
-                Player player = Bukkit.getServer().getPlayerExact(playerName);
+            for (Entry<String, EntryFields> playerEntry : dynamicEntries.entrySet()) {
+                Player player = Bukkit.getServer().getPlayerExact(playerEntry.getKey());
 
                 if (player == null) {
                     continue;
                 }
 
-                EntryFields ef = dynamicEntries.get(playerName);
+                EntryFields ef = playerEntry.getValue();
                 List<Field> fields = ef.getFields();
 
                 boolean hasDamage = false;
@@ -641,14 +642,14 @@ public final class EntryManager {
      */
     public void removeAllPlayers(Field field) {
         synchronized (entriesByPlayer) {
-            for (String playerName : entriesByPlayer.keySet()) {
-                Player player = Bukkit.getServer().getPlayerExact(playerName);
+            for (Entry<String, EntryFields> playerEntry : entriesByPlayer.entrySet()) {
+                Player player = Bukkit.getServer().getPlayerExact(playerEntry.getKey());
 
                 if (player == null) {
                     continue;
                 }
 
-                EntryFields ef = entriesByPlayer.get(playerName);
+                EntryFields ef = playerEntry.getValue();
                 List<Field> fields = ef.getFields();
 
                 for (Iterator iter = fields.iterator(); iter.hasNext(); ) {
@@ -664,14 +665,14 @@ public final class EntryManager {
         }
 
         synchronized (dynamicEntries) {
-            for (String playerName : dynamicEntries.keySet()) {
-                Player player = Bukkit.getServer().getPlayerExact(playerName);
+            for (Entry<String, EntryFields> playerEntry : dynamicEntries.entrySet()) {
+                Player player = Bukkit.getServer().getPlayerExact(playerEntry.getKey());
 
                 if (player == null) {
                     continue;
                 }
 
-                EntryFields ef = dynamicEntries.get(playerName);
+                EntryFields ef = playerEntry.getValue();
                 List<Field> fields = ef.getFields();
 
                 for (Iterator iter = fields.iterator(); iter.hasNext(); ) {
@@ -764,13 +765,13 @@ public final class EntryManager {
         HashSet<String> inhabitants = new HashSet<String>();
 
         synchronized (entriesByPlayer) {
-            for (String playerName : entriesByPlayer.keySet()) {
-                EntryFields ef = entriesByPlayer.get(playerName);
+            for (Entry<String, EntryFields> playerEntry : entriesByPlayer.entrySet()) {
+                EntryFields ef = playerEntry.getValue();
                 List<Field> fields = ef.getFields();
 
                 for (Field testfield : fields) {
                     if (field.equals(testfield)) {
-                        inhabitants.add(playerName);
+                        inhabitants.add(playerEntry.getKey());
                     }
                 }
             }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/ForceFieldManager.java
@@ -26,6 +26,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Handles fields
@@ -446,10 +447,9 @@ public final class ForceFieldManager {
         // remove from flags collection
 
         if (field.getSettings() != null) {
-            Set<FieldFlag> flags = fieldsByFlag.keySet();
 
-            for (FieldFlag flag : flags) {
-                List<Field> fields = fieldsByFlag.get(flag);
+            for (Entry<FieldFlag, List<Field>> fieldSetting : fieldsByFlag.entrySet()) {
+                List<Field> fields = fieldSetting.getValue();
 
                 if (fields != null) {
                     fields.remove(field);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PotionManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/PotionManager.java
@@ -12,6 +12,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map.Entry;
 
 /**
  * @author telaeris
@@ -30,8 +31,9 @@ public class PotionManager {
         HashMap<PotionEffectType, Integer> potions = field.getSettings().getPotions();
         String names = "";
 
-        for (PotionEffectType pot : potions.keySet()) {
-            int intensity = potions.get(pot);
+        for (Entry<PotionEffectType, Integer> potion : potions.entrySet()) {
+            int intensity = potion.getValue();
+            PotionEffectType pot = potion.getKey();
 
             if (!player.hasPotionEffect(pot)) {
                 if (plugin.getPermissionsManager().has(player, "preciousstones.manual.bypass.potions")) {

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/StorageManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/StorageManager.java
@@ -31,6 +31,7 @@ import org.joda.time.Days;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -2281,11 +2282,11 @@ public class StorageManager {
             PreciousStones.getLog().info("[Queue] processing " + workingUb.size() + " unbreakable queries...");
         }
 
-        for (Unbreakable ub : workingUb.keySet()) {
-            if (workingUb.get(ub)) {
-                insertUnbreakable(ub);
+        for (Entry<Unbreakable, Boolean> ub : workingUb.entrySet()) {
+            if (workingUb.get(ub.getValue())) {
+                insertUnbreakable(ub.getKey());
             } else {
-                deleteUnbreakable(ub);
+                deleteUnbreakable(ub.getKey());
             }
         }
     }

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/VisualizationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/VisualizationManager.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 
 /**
  * @author phad
@@ -71,9 +72,9 @@ public class VisualizationManager {
      * Reverts all current visualizations
      */
     public void revertAll() {
-        for (String playerName : visualizations.keySet()) {
-            Visualization vis = visualizations.get(playerName);
-            Player player = Bukkit.getServer().getPlayerExact(playerName);
+        for (Entry<String, Visualization> visualization : visualizations.entrySet()) {
+            Visualization vis = visualization.getValue();
+            Player player = Bukkit.getServer().getPlayerExact(visualization.getKey());
 
             if (player != null) {
                 Visualize visualize = new Visualize(vis.getBlocks(), player, true, false, 0);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed