### PR TITLE
Code quality fix - Identical expressions should not be used on both sides of a binary operator.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/field/Field.java
@@ -1166,7 +1166,6 @@ public class Field extends AbstractVec implements Comparable<Field> {
                 if (flags.hasFlag(FieldFlag.TELEPORT_PLAYERS_ON_ENABLE) ||
                         flags.hasFlag(FieldFlag.TELEPORT_MOBS_ON_ENABLE) ||
                         flags.hasFlag(FieldFlag.TELEPORT_VILLAGERS_ON_ENABLE) ||
-                        flags.hasFlag(FieldFlag.TELEPORT_ANIMALS_ON_ENABLE) ||
                         flags.hasFlag(FieldFlag.TELEPORT_ANIMALS_ON_ENABLE)) {
                     List<Entity> entities = Bukkit.getServer().getWorld(this.getWorld()).getEntities();
 

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SettingsManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/SettingsManager.java
@@ -1427,7 +1427,7 @@ public final class SettingsManager {
     }
 
     public boolean isNaturalFloorType(int type) {
-        return type == 1 || type == 2 || type == 3 || type == 4 || type == 7 || type == 12 || type == 13 || type == 14 || type == 15 || type == 16 || type == 17 || type == 21 || type == 60 || type == 73 || type == 74 || type == 80 || type == 82 || type == 87 || type == 88 || type == 110 || type == 97 || type == 82 || type == 129;
+        return type == 1 || type == 2 || type == 3 || type == 4 || type == 7 || type == 12 || type == 13 || type == 14 || type == 15 || type == 16 || type == 17 || type == 21 || type == 60 || type == 73 || type == 74 || type == 80 || type == 82 || type == 87 || type == 88 || type == 110 || type == 97 || type == 129;
     }
 
     public boolean isOncePerBlockOnMove() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1764 - Identical expressions should not be used on both sides of a binary operator.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1764

Please let me know if you have any questions.

Faisal Hameed