### PR TITLE
Code quality fix - "return" statements should not occur in "finally" blocks.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/MySQLCore.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/MySQLCore.java
@@ -105,7 +105,6 @@ public class MySQLCore implements DBCore {
      */
     public long insert(String query) {
         PreciousStones.debug(query);
-        long key = 0;
 
         try {
             Statement statement = getConnection().createStatement();
@@ -114,20 +113,18 @@ public class MySQLCore implements DBCore {
             try {
                 statement.executeUpdate(query, Statement.RETURN_GENERATED_KEYS);
                 keys = statement.getGeneratedKeys();
+                if (keys != null) {
+                    if (keys.next()) {
+                        return keys.getLong(1);
+                    }
+                }
             } catch (SQLException ex) {
                 if (!ex.toString().contains("not return ResultSet")) {
                     log.severe("Error at SQL INSERT Query: " + ex);
                 }
             } finally {
-                if (keys != null) {
-                    if (keys.next()) {
-                        key = keys.getLong(1);
-                    }
-                }
                 statement.close();
-            }
-
-            return key;
+            }            
         } catch (SQLException ex) {
             if (!ex.toString().contains("not return ResultSet")) {
                 log.severe("Error at SQL INSERT Query: " + ex);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/SQLiteCore.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/storage/SQLiteCore.java
@@ -119,20 +119,17 @@ public class SQLiteCore implements DBCore {
             try {
                 statement.executeUpdate(query);
                 keys = statement.executeQuery("SELECT last_insert_rowid()");
+                if (keys != null) {
+                    if (keys.next()) {
+                        return keys.getLong(1);
+                    }
+                }
             } catch (SQLException ex) {
                 if (!ex.toString().contains("not return ResultSet")) {
                     log.severe("Error at SQL INSERT Query: " + ex);
                 }
             } finally {
-                if (keys != null) {
-                    if (keys.next()) {
-                        long key = keys.getLong(1);
-                        statement.close();
-                        return key;
-                    }
-                }
                 statement.close();
-                return 0;
             }
         } catch (SQLException ex) {
             if (!ex.toString().contains("not return ResultSet")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1143 - "return" statements should not occur in "finally" blocks. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1143

Please let me know if you have any questions.

Faisal Hameed