### PR TITLE
Fix Godstones

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
@@ -146,17 +146,19 @@ public final class EntryManager {
                             if (FieldFlag.REPAIR.applies(field, player)) {
                                 ItemStack[] armors = player.getInventory().getArmorContents();
                                 for (ItemStack armor : armors) {
-                                    if (plugin.getSettingsManager().isRepairableItemType(new BlockTypeEntry(armor.getType()))) {
-                                        short dur = armor.getDurability();
-                                        if (dur > 0) {
-                                            dur -= field.getSettings().getRepair();
-                                            if (dur < 0) {
-                                                dur = 0;
+                                    if(armor != null) {
+                                        if (plugin.getSettingsManager().isRepairableItemType(new BlockTypeEntry(armor.getType()))) {
+                                            short dur = armor.getDurability();
+                                            if (dur > 0) {
+                                                dur -= field.getSettings().getRepair();
+                                                if (dur < 0) {
+                                                    dur = 0;
+                                                }
+                                                armor.setDurability(dur);
+                                                plugin.getCommunicationManager().showRepair(player);
+                                                hasRepair = true;
+                                                break;
                                             }
-                                            armor.setDurability(dur);
-                                            plugin.getCommunicationManager().showRepair(player);
-                                            hasRepair = true;
-                                            break;
                                         }
                                     }
                                 }


### PR DESCRIPTION
This is just a simple null-check.
Previously, if any piece of armour was missing (or 'null'), this would SILENTLY error and quit entirely.