### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/ItemStackEntry.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/entries/ItemStackEntry.java
@@ -142,7 +142,7 @@ public class ItemStackEntry {
     @Override
     public String toString() {
         if (getData() == 0) {
-            return getTypeId() + "";
+            return Integer.toString(getTypeId());
         }
 
         if (getDurability() == 0) {

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/Helper.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/helpers/Helper.java
@@ -239,7 +239,7 @@ public class Helper {
      */
     public static String friendlyBlockType(int typeId) {
         if (Material.getMaterial(typeId) == null) {
-            return typeId + "";
+            return Integer.toString(typeId);
         }
 
         return MaterialName.getIDName(Material.getMaterial(typeId));
@@ -705,7 +705,7 @@ public class Helper {
      */
     public static String getMaterialString(int typeId) {
         if (Material.getMaterial(typeId) == null) {
-            return typeId + "";
+            return Integer.toString(typeId);
         }
 
         return Material.getMaterial(typeId).toString();

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/CommunicationManager.java
@@ -2535,7 +2535,7 @@ public class CommunicationManager {
 
             ChatColor color = (count < limit) || limit == -1 ? ChatColor.WHITE : ChatColor.DARK_RED;
 
-            String strLimit = limit == -1 ? "-" : limit + "";
+            String strLimit = limit == -1 ? "-" : Integer.toString(limit);
 
             if (plugin.getSettingsManager().haveLimits()) {
                 cb.addRow("  " + ChatColor.AQUA + fs.getTitle(), "{yellow} " + count, color + " " + strLimit);

--- a/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
+++ b/src/main/java/net/sacredlabyrinth/Phaed/PreciousStones/managers/EntryManager.java
@@ -784,9 +784,9 @@ public final class EntryManager {
                 for (String cmd : field.getSettings().getCommandsOnEnter()) {
                     cmd = cmd.replace("{player}", player.getName());
                     cmd = cmd.replace("{owner}", field.getOwner());
-                    cmd = cmd.replace("{x}", player.getLocation().getBlockX() + "");
-                    cmd = cmd.replace("{y}", player.getLocation().getBlockY() + "");
-                    cmd = cmd.replace("{z}", player.getLocation().getBlockZ() + "");
+                    cmd = cmd.replace("{x}", Integer.toString(player.getLocation().getBlockX()));
+                    cmd = cmd.replace("{y}", Integer.toString(player.getLocation().getBlockY()));
+                    cmd = cmd.replace("{z}", Integer.toString(player.getLocation().getBlockZ()));
                     cmd = cmd.replace("{world}", player.getLocation().getWorld().getName());
 
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
@@ -799,9 +799,9 @@ public final class EntryManager {
                 for (String cmd : field.getSettings().getPlayerCommandsOnEnter()) {
                     cmd = cmd.replace("{player}", player.getName());
                     cmd = cmd.replace("{owner}", field.getOwner());
-                    cmd = cmd.replace("{x}", player.getLocation().getBlockX() + "");
-                    cmd = cmd.replace("{y}", player.getLocation().getBlockY() + "");
-                    cmd = cmd.replace("{z}", player.getLocation().getBlockZ() + "");
+                    cmd = cmd.replace("{x}", Integer.toString(player.getLocation().getBlockX()));
+                    cmd = cmd.replace("{y}", Integer.toString(player.getLocation().getBlockY()));
+                    cmd = cmd.replace("{z}", Integer.toString(player.getLocation().getBlockZ()));
                     cmd = cmd.replace("{world}", player.getLocation().getWorld().getName());
 
                     player.performCommand(cmd);
@@ -816,9 +816,9 @@ public final class EntryManager {
                 for (String cmd : field.getSettings().getCommandsOnExit()) {
                     cmd = cmd.replace("{player}", player.getName());
                     cmd = cmd.replace("{owner}", field.getOwner());
-                    cmd = cmd.replace("{x}", player.getLocation().getBlockX() + "");
-                    cmd = cmd.replace("{y}", player.getLocation().getBlockY() + "");
-                    cmd = cmd.replace("{z}", player.getLocation().getBlockZ() + "");
+                    cmd = cmd.replace("{x}", Integer.toString(player.getLocation().getBlockX()));
+                    cmd = cmd.replace("{y}", Integer.toString(player.getLocation().getBlockY()));
+                    cmd = cmd.replace("{z}", Integer.toString(player.getLocation().getBlockZ()));
                     cmd = cmd.replace("{world}", player.getLocation().getWorld().getName());
 
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
@@ -831,9 +831,9 @@ public final class EntryManager {
                 for (String cmd : field.getSettings().getPlayerCommandsOnExit()) {
                     cmd = cmd.replace("{player}", player.getName());
                     cmd = cmd.replace("{owner}", field.getOwner());
-                    cmd = cmd.replace("{x}", player.getLocation().getBlockX() + "");
-                    cmd = cmd.replace("{y}", player.getLocation().getBlockY() + "");
-                    cmd = cmd.replace("{z}", player.getLocation().getBlockZ() + "");
+                    cmd = cmd.replace("{x}", Integer.toString(player.getLocation().getBlockX()));
+                    cmd = cmd.replace("{y}", Integer.toString(player.getLocation().getBlockY()));
+                    cmd = cmd.replace("{z}", Integer.toString(player.getLocation().getBlockZ()));
                     cmd = cmd.replace("{world}", player.getLocation().getWorld().getName());
 
                     player.performCommand(cmd);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed
